### PR TITLE
Add GitHub Actions smoke tests for pack-based installs

### DIFF
--- a/.github/ci/init.lua
+++ b/.github/ci/init.lua
@@ -1,0 +1,16 @@
+vim.loader.enable()
+
+local repo = assert(vim.env.LYAML_REPO, 'Missing LYAML_REPO environment variable')
+if not repo:match('^file://') then
+  repo = 'file://' .. repo
+end
+
+local spec = {
+  {
+    name = 'lyaml.nvim',
+    src = repo,
+    version = vim.env.LYAML_REF,
+  },
+}
+
+vim.pack.add(spec, { load = true, confirm = false })

--- a/.github/ci/lua/ci/smoke.lua
+++ b/.github/ci/lua/ci/smoke.lua
@@ -1,0 +1,35 @@
+local M = {}
+
+local function assert_eq(actual, expected, message)
+  if actual ~= expected then
+    error(message or string.format('expected %q but got %q', expected, actual), 2)
+  end
+end
+
+local function ensure(condition, message)
+  if not condition then
+    error(message or 'assertion failed', 2)
+  end
+end
+
+function M.run()
+  local lyaml = require('lyaml')
+
+  local stream = table.concat({ '- alpha', '- beta' }, '\n')
+  local data = assert(lyaml.load(stream), 'failed to load inline yaml stream')
+  assert_eq(data[1], 'alpha', 'unexpected first element from stream load')
+  assert_eq(data[2], 'beta', 'unexpected second element from stream load')
+
+  local tmp = vim.fs.joinpath(vim.fn.stdpath('state'), 'ci-sample.yaml')
+  vim.fn.mkdir(vim.fs.dirname(tmp), 'p')
+  vim.fn.writefile({ 'greeting: hello' }, tmp)
+  local lines = vim.fn.readfile(tmp)
+  ensure(#lines > 0, 'yaml file should not be empty')
+
+  local parsed = assert(lyaml.load(table.concat(lines, '\n')), 'failed to load yaml file contents')
+  assert_eq(parsed.greeting, 'hello', 'yaml file contents parsed incorrectly')
+
+  vim.pack.update({ 'lyaml.nvim' }, { force = true })
+end
+
+return M

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,60 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  smoke:
+    name: Smoke test (${{ matrix.label }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: Ubuntu 24.04
+            image: ubuntu:24.04
+            setup: |
+              apt-get update
+              DEBIAN_FRONTEND=noninteractive apt-get install -y \
+                build-essential \
+                ca-certificates \
+                git \
+                neovim \
+                pkg-config
+          - label: Arch Linux
+            image: archlinux:latest
+            setup: |
+              pacman -Sy --noconfirm archlinux-keyring
+              pacman -Syu --noconfirm
+              pacman -S --noconfirm --needed \
+                base-devel \
+                git \
+                neovim
+    container:
+      image: ${{ matrix.image }}
+      options: --env CI=1
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          set -euxo pipefail
+          ${{ matrix.setup }}
+
+      - name: Run Neovim smoke tests
+        env:
+          NVIM_APPNAME: ci-lyaml
+          LYAML_REPO: ${{ github.workspace }}
+          LYAML_REF: ${{ github.sha }}
+        run: |
+          set -euxo pipefail
+          config_dir="$HOME/.config/${NVIM_APPNAME}"
+          mkdir -p "$config_dir/lua/ci"
+          cp .github/ci/init.lua "$config_dir/init.lua"
+          cp .github/ci/lua/ci/smoke.lua "$config_dir/lua/ci/smoke.lua"
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          nvim --version
+          nvim --headless '+lua require("ci.smoke").run()' +qa


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that runs smoke tests inside Ubuntu and Arch Linux containers
- provision Neovim build dependencies and bootstrap the plugin using the `vim.pack.add` API
- exercise YAML parsing and plugin updates through headless Neovim smoke tests

## Testing
- ./nvim-linux-x86_64/bin/nvim --headless '+lua require("ci.smoke").run()' +qa


------
https://chatgpt.com/codex/tasks/task_b_68d85dd83e9c8327b2395185bf87353f